### PR TITLE
Implemented a new (and hopefully more optimal) Batch statement

### DIFF
--- a/src/batch.go
+++ b/src/batch.go
@@ -6,6 +6,7 @@ import (
 	"github.com/RHUL-CS-Projects/IndividualProject_2021_Jakab.Zeller/src/data"
 	"github.com/RHUL-CS-Projects/IndividualProject_2021_Jakab.Zeller/src/parser"
 	"strings"
+	"sync"
 )
 
 // MaxWorkers are the max number of worker goroutines we can create in our pool.
@@ -69,28 +70,50 @@ func (b *BatchResults) String() string {
 	return builder.String()
 }
 
-// BatchSuite represents a currently running parser.Batch statement. It contains a list of BatchItems that can be 
-// executed using Execute.
+// BatchSuite represents a currently running parser.Batch statement. It contains the properties required to manage the
+// worker pool that will be started to execute the MethodCalls enqueued in it.
 type BatchSuite struct {
+	// BatchStatement is the AST node that this BatchSuite is related to.
 	BatchStatement *parser.Batch
-	Batch          []*BatchItem
+	// Results is a heap.Interface that has the results of every job that was enqueued into the BatchSuite, in the order
+	// that it was enqueued.
+	Results        BatchResults
+	// CurrentId is a counter for the ID that is given to each enqueued job.
 	CurrentId      int
+	// jobChan is a buffered channel that holds the jobs to execute within the worker goroutines.
+	jobChan        chan *BatchItem
+	// resultChan is a buffered channel that the workers enqueue their results into.
+	resultChan     chan *BatchResult
+	// consumerDone is an unbuffered channel used to block the interpreter thread until the consumer has added all the 
+	// results to Results.
+	consumerDone   chan struct{}
+	// workerGroup is a sync.WaitGroup that is used to wait until all workers have executed the work that they have been
+	// given.
+	workerGroup    sync.WaitGroup
+	// close is used to execute the Stop only once, so that no panics occur if the channels (mentioned above) are 
+	// already closed.
+	close          sync.Once
 }
 
-// Batch creates a new BatchSuite. 
+// Batch creates a new BatchSuite. It creates buffered job and result channels that have a capacity of MaxWorkers.
 func Batch(statement *parser.Batch) *BatchSuite {
 	return &BatchSuite{
 		BatchStatement: statement,
-		Batch:          make([]*BatchItem, 0),
+		Results:        make(BatchResults, 0),
 		CurrentId:      0,
+		jobChan:        make(chan *BatchItem, MaxWorkers),
+		resultChan:     make(chan *BatchResult, MaxWorkers),
+		consumerDone:   make(chan struct{}),
 	}
 }
 
 // methodWorker is the worker routine used within the BatchSuite.Execute function. It reads from a channel of jobs and 
-// writes to a channel of results.
-func methodWorker(jobs <-chan *BatchItem, results chan<- *BatchResult) {
+// writes to a channel of results. When finished, the worker decrements a sync.WaitGroup.
+func methodWorker(wg *sync.WaitGroup, jobs <-chan *BatchItem, results chan<- *BatchResult) {
+	defer wg.Done()
 	for j := range jobs {
-		// Call eval.Method.Call for the parser.MethodCall's eval.Method and queue the result and err up in a BatchResult
+		// Call eval.Method.Call for the parser.MethodCall's eval.Method and queue the result and err up in a 
+		// BatchResult
 		err, result := j.Method.Method.Call(j.Args...)
 		results <- &BatchResult{
 			Id:     j.Id,
@@ -101,19 +124,14 @@ func methodWorker(jobs <-chan *BatchItem, results chan<- *BatchResult) {
 	}
 }
 
-// AddWork will create and append a BatchItem to the Batch.
+// AddWork will enqueue the given parser.MethodCall, and its args, as a BatchItem to be executed by the workers.
 func (b *BatchSuite) AddWork(method *parser.MethodCall, args... *data.Value) {
-	b.Batch = append(b.Batch, &BatchItem{
+	b.jobChan <- &BatchItem{
 		Method: method,
 		Args:   args,
 		Id:     b.CurrentId,
-	})
+	}
 	b.CurrentId ++
-}
-
-// Work returns the number of jobs added to the batch so far.
-func (b *BatchSuite) Work() int {
-	return len(b.Batch)
 }
 
 // GetStatement will return a pointer to a parser.Batch statement so that it can be compared and or set.
@@ -121,40 +139,39 @@ func (b *BatchSuite) GetStatement() *parser.Batch {
 	return b.BatchStatement
 }
 
-// Execute will spin up a number of worker goroutines and then enqueue all the BatchItems in the Batch to a work queue.
-// The results will be dequeued from the result queue and added back to a BatchResult queue in the order in which they 
-// were added to the Batch. The workers parameter indicates the number of workers to spin up. If a negative number is 
-// given then the workers will match the length of the job queue, clamped to MaxWorkers. If the number is not negative 
-// then the number of workers will be locked to that number, also clamped to MaxWorkers.
-func (b *BatchSuite) Execute(workers int) heap.Interface {
-	numJobs := len(b.Batch)
-	jobs := make(chan *BatchItem, numJobs)
-	results := make(chan *BatchResult, numJobs)
-
-	// We decide how many workers to spin up by looking at the number of jobs we have as well as the workers parameter.
-	if workers < 0 {
-		workers = numJobs
-	}
-	if numJobs > MaxWorkers {
+// Start will spin-up the worker goroutines that will be fed the work accumulated over the course of a batch statement.
+// Can be given the number of workers to spin up, if this is a negative integer, or the number of workers exceeds 
+// MaxWorkers, then MaxWorkers will be used instead. A consumer goroutine will pull results from the result channel and
+// push them to the Results heap.
+func (b *BatchSuite) Start(workers int) {
+	if workers < 0 || workers > MaxWorkers {
 		workers = MaxWorkers
 	}
 
 	// We spin up the workers
-	for w := 1; w <= workers; w++ {
-		go methodWorker(jobs, results)
+	for w := 0; w < workers; w++ {
+		b.workerGroup.Add(1)
+		go methodWorker(&b.workerGroup, b.jobChan, b.resultChan)
 	}
 
-	// Add all the BatchItems as jobs to the jobs queue
-	for _, item := range b.Batch {
-		jobs <- item
-	}
-	// Close all the jobs
-	close(jobs)
+	// Start a consumer goroutine that will consume results and append them to the heap. We only start one consumer 
+	// because it does not make sense to try and manage a mutex between several.
+	go func() {
+		for result := range b.resultChan {
+			heap.Push(&b.Results, result)
+		}
+		b.consumerDone <- struct{}{}
+	}()
+}
 
-	// Add each result to the BatchResult queue in the order they came in
-	orderedResults := make(BatchResults, 0, numJobs)
-	for r := 1; r <= numJobs; r++ {
-		heap.Push(&orderedResults, <-results)
-	}
-	return &orderedResults
+// Stop will close the Batch channel, indicating to the workers that there is no more work to execute. We will also wait
+// for the result consumer to finish.
+func (b *BatchSuite) Stop() heap.Interface {
+	b.close.Do(func() {
+		close(b.jobChan)
+		b.workerGroup.Wait()
+		close(b.resultChan)
+		<-b.consumerDone
+	})
+	return &b.Results
 }

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -444,8 +444,11 @@ func TestBatchSuite_Execute(t *testing.T) {
 		},
 	}{
 		batch := Batch(nil)
-		batch.Batch = test.items
-		results := batch.Execute(-1)
+		batch.Start(-1)
+		for _, item := range test.items {
+			batch.AddWork(item.Method, item.Args...)
+		}
+		results := batch.Stop()
 		heap.Init(&test.expected)
 
 		if results.Len() != len(test.expected) {

--- a/src/parser/interfaces.go
+++ b/src/parser/interfaces.go
@@ -55,8 +55,11 @@ type VM interface {
 	DeleteBatch()
 	// CreateBatch will create a new BatchSuite for the given Batch AST node.
 	CreateBatch(statement *Batch)
-	// ExecuteBatch will execute the current BatchSuite and store the results in the VM state accessible via GetBatch.
-	ExecuteBatch()
+	// StartBatch will start the worker threads for the batch, ready to execute any MethodCall(s) enqueued as work.
+	StartBatch()
+	// StopBatch will stop indicate to the internal Batch that there is no more work to execute and that we want to wait
+	// for the workers to be finish. It should also set the BatchResults field to the results of this Batch.
+	StopBatch()
 	// GetEnvironment will return the currently used environment, or nil if there is no environment.
 	GetEnvironment() (err error, env Env)
 }
@@ -110,9 +113,9 @@ type BatchResult interface {
 // BatchSuite represents the suite that is used to execute a Batch statement.
 type BatchSuite interface {
 	AddWork(method *MethodCall, args... *data.Value)
-	Work() int
 	GetStatement() *Batch
-	Execute(workers int) heap.Interface
+	Start(workers int)
+	Stop() heap.Interface
 }
 
 // Env represents an environment variable that can be passed to a VM to set a global constant.

--- a/src/vm.go
+++ b/src/vm.go
@@ -149,8 +149,9 @@ func (vm *VM) GetBatch() (parser.BatchSuite, heap.Interface) {
 	return vm.Batch, vm.BatchResults
 }
 
-// DeleteBatch will nullify the Batch.
+// DeleteBatch will stop the workers, then nullify the Batch.
 func (vm *VM) DeleteBatch() {
+	vm.Batch.Stop()
 	vm.Batch = nil
 	vm.BatchResults = nil
 }
@@ -159,9 +160,12 @@ func (vm *VM) CreateBatch(statement *parser.Batch) {
 	vm.Batch = Batch(statement)
 }
 
-// ExecuteBatch will execute the batched MethodCalls and store them in BatchResults.
-func (vm *VM) ExecuteBatch() {
-	vm.BatchResults = vm.Batch.Execute(-1)
+func (vm *VM) StartBatch() {
+	vm.Batch.Start(-1)
+}
+
+func (vm *VM) StopBatch() {
+	vm.BatchResults = vm.Batch.Stop()
 }
 
 func (vm *VM) GetEnvironment() (err error, env parser.Env) {


### PR DESCRIPTION
This new batch statement will start its workers before executing the
first pass. The interpreter will then enqueue each MethodCall it finds
in the first pass as a unit of work for the worker pool to execute.

Whenever a worker produces a result it will be enqueued in the result
queue. Results in this queue are then consumed by a consumer that pushes
each result onto the Results heap (heap.Interface).

Once the first pass has completed the interpreter is blocked until the
BatchSuite has executed all of its work. After this the execution is
similar to the old batch statement.

From inital benchmarking this implementation is around 50% faster
overall than the old batch statement implementation. More testing needs
to be done, however...